### PR TITLE
Update to work with flutter v1.13

### DIFF
--- a/lib/src/cupertino_localizations.dart
+++ b/lib/src/cupertino_localizations.dart
@@ -139,7 +139,7 @@ class _CupertinoLocalizationsDelegate extends LocalizationsDelegate<CupertinoLoc
 
       assert(locale.toString() == localeName, 'comparing "$locale" to "$localeName"');
 
-      return SynchronousFuture<CupertinoLocalizations>(getCupertinoTranslation(
+      return SynchronousFuture<CupertinoLocalizations>(getCupertinoTranslationLocal(
         locale,
       ));
     });

--- a/lib/src/cupertino_localizations.dart
+++ b/lib/src/cupertino_localizations.dart
@@ -127,7 +127,7 @@ class _CupertinoLocalizationsDelegate extends LocalizationsDelegate<CupertinoLoc
   const _CupertinoLocalizationsDelegate();
 
   @override
-  bool isSupported(Locale locale) => kSupportedLanguages.contains(locale.languageCode);
+  bool isSupported(Locale locale) => kCupertinoSupportedLanguages.contains(locale.languageCode);
 
   static final Map<Locale, Future<CupertinoLocalizations>> _loadedTranslations = <Locale, Future<CupertinoLocalizations>>{};
 
@@ -149,5 +149,5 @@ class _CupertinoLocalizationsDelegate extends LocalizationsDelegate<CupertinoLoc
   bool shouldReload(_CupertinoLocalizationsDelegate old) => false;
 
   @override
-  String toString() => 'GlobalCupertinoLocalizations.delegate(${kSupportedLanguages.length} locales)';
+  String toString() => 'GlobalCupertinoLocalizations.delegate(${kCupertinoSupportedLanguages.length} locales)';
 }

--- a/lib/src/cupertino_localizations.dart
+++ b/lib/src/cupertino_localizations.dart
@@ -75,6 +75,9 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
   String get selectAllButtonLabel => _localizations.selectAllButtonLabel;
 
   @override
+  String get todayLabel => "Today";
+
+  @override
   String datePickerMediumDate(DateTime date) {
     return _localizations.formatMediumDate(date);
   }

--- a/lib/src/l10n/localizations.dart
+++ b/lib/src/l10n/localizations.dart
@@ -2486,6 +2486,9 @@ class CupertinoLocalizationZh extends GlobalCupertinoLocalizations {
   CupertinoLocalizationZh({@required Locale locale}) : super(locale: locale);
 
   @override
+  String get todayLabel => "今天";
+
+  @override
   DatePickerDateOrder get datePickerDateOrder => DatePickerDateOrder.ymd;
 
   @override

--- a/lib/src/l10n/localizations.dart
+++ b/lib/src/l10n/localizations.dart
@@ -2668,7 +2668,7 @@ class CupertinoLocalizationZhHantTw extends CupertinoLocalizationZhHant {
 ///
 /// Generally speaking, this method is only intended to be used by
 /// [GlobalCupertinoLocalizations.delegate].
-GlobalCupertinoLocalizations getCupertinoTranslation(
+GlobalCupertinoLocalizations getCupertinoTranslationLocal(
   Locale locale,
 ) {
   switch (locale.languageCode) {


### PR DESCRIPTION
* Fix missing `todayLabel` implementation error #2 
* Fix missing `kSupportedLanguages` implementation error #3 
* Fix `getCupertinoTranslation` is imported from multiple packages error
faa10e1